### PR TITLE
Add Freertos headers

### DIFF
--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -1,8 +1,13 @@
 #ifndef _MQTT_H_
 #define _MQTT_H_
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+
 #include "mqtt_config.h"
 #include "mqtt_msg.h"
 #include "ringbuf.h"


### PR DESCRIPTION
Pretty self explanatory.
Build wasn't working (missing header for `QueueHandle_t`), now it is :)

Thanks for the library!