### PR TITLE
Keppalive issue

### DIFF
--- a/lib/include/platform_esp32_idf.h
+++ b/lib/include/platform_esp32_idf.h
@@ -27,5 +27,5 @@
 
 char *platform_create_id_string();
 int platform_random(int max);
-int platform_tick_get_ms();
+long long platform_tick_get_ms();
 #endif

--- a/lib/platform_esp32_idf.c
+++ b/lib/platform_esp32_idf.c
@@ -19,7 +19,7 @@ int platform_random(int max)
     return esp_random()%max;
 }
 
-int platform_tick_get_ms()
+long long platform_tick_get_ms()
 {
     struct timeval te;
     gettimeofday(&te, NULL); // get current time

--- a/mqtt_client.c
+++ b/mqtt_client.c
@@ -61,8 +61,8 @@ struct esp_mqtt_client {
     mqtt_state_t  mqtt_state;
     mqtt_connect_info_t connect_info;
     mqtt_client_state_t state;
-    int keepalive_tick;
-    int reconnect_tick;
+    long long keepalive_tick;
+    long long reconnect_tick;
     int wait_timeout_ms;
     int auto_reconnect;
     esp_mqtt_event_t event;
@@ -310,8 +310,8 @@ esp_mqtt_client_handle_t esp_mqtt_client_init(const esp_mqtt_client_config_t *co
         client->config->scheme = create_string("mqtt", 4);
     }
 
-    client->keepalive_tick = 0;
-    client->reconnect_tick = 0;
+    client->keepalive_tick = platform_tick_get_ms();
+    client->reconnect_tick = platform_tick_get_ms();
 
     int buffer_size = config->buffer_size;
     if (buffer_size <= 0) {


### PR DESCRIPTION
There is no keepalive packget if current time is very large. Caused by integer overflow.