### PR TITLE
fix: add header "esp_err.h"

### DIFF
--- a/include/mqtt_client.h
+++ b/include/mqtt_client.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+#include "esp_err.h"
 
 #include "mqtt_config.h"
 


### PR DESCRIPTION
use type esp_err_t but you not include it's header