### PR TITLE
Add cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(COMPONENT_ADD_INCLUDEDIRS "include")
+set(COMPONENT_PRIV_INCLUDEDIRS "lib/include")
+set(COMPONENT_SRCDIRS ". lib")
+
+set(COMPONENT_REQUIRES lwip nghttp)
+
+register_component()
+

--- a/examples/mqtt_ssl/CMakeLists.txt
+++ b/examples/mqtt_ssl/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.5)
+
+get_filename_component(DEV_ROOT "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+
+set(PROJECT_ROOT "${DEV_ROOT}/")
+
+set(SUBMODULE_ROOT "${DEV_ROOT}/../../../")
+
+set(PROJECT_NAME "mqtt_ssl")
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+set(MAIN_SRCS ${PROJECT_ROOT}/main/app_main.c)
+
+set(EXTRA_COMPONENT_DIRS "${EXTRA_COMPONENT_DIRS} ${SUBMODULE_ROOT}")
+set(BUILD_COMPONENTS "${BUILD_COMPONENTS} espmqtt")
+
+project(${PROJECT_NAME})
+

--- a/examples/mqtt_tcp/CMakeLists.txt
+++ b/examples/mqtt_tcp/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.5)
+
+get_filename_component(DEV_ROOT "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+
+set(PROJECT_ROOT "${DEV_ROOT}/")
+
+set(SUBMODULE_ROOT "${DEV_ROOT}/../../../")
+
+set(PROJECT_NAME "mqtt_tcp")
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+set(MAIN_SRCS ${PROJECT_ROOT}/main/app_main.c)
+
+set(EXTRA_COMPONENT_DIRS "${EXTRA_COMPONENT_DIRS} ${SUBMODULE_ROOT}")
+set(BUILD_COMPONENTS "${BUILD_COMPONENTS} espmqtt")
+
+project(${PROJECT_NAME})
+

--- a/examples/mqtt_ws/CMakeLists.txt
+++ b/examples/mqtt_ws/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.5)
+
+get_filename_component(DEV_ROOT "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+
+set(PROJECT_ROOT "${DEV_ROOT}/")
+
+set(SUBMODULE_ROOT "${DEV_ROOT}/../../../")
+
+set(PROJECT_NAME "mqtt_ws")
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+set(MAIN_SRCS ${PROJECT_ROOT}/main/app_main.c)
+
+set(EXTRA_COMPONENT_DIRS "${EXTRA_COMPONENT_DIRS} ${SUBMODULE_ROOT}")
+set(BUILD_COMPONENTS "${BUILD_COMPONENTS} espmqtt")
+
+project(${PROJECT_NAME})
+

--- a/examples/mqtt_wss/CMakeLists.txt
+++ b/examples/mqtt_wss/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.5)
+
+get_filename_component(DEV_ROOT "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+
+set(PROJECT_ROOT "${DEV_ROOT}/")
+
+set(SUBMODULE_ROOT "${DEV_ROOT}/../../../")
+
+set(PROJECT_NAME "mqtt_wss")
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+set(MAIN_SRCS ${PROJECT_ROOT}/main/app_main.c)
+
+set(EXTRA_COMPONENT_DIRS "${EXTRA_COMPONENT_DIRS} ${SUBMODULE_ROOT}")
+set(BUILD_COMPONENTS "${BUILD_COMPONENTS} espmqtt")
+
+project(${PROJECT_NAME})
+


### PR DESCRIPTION
The new esp-idf build system is based on cmake.
Components require their own CMakeLists.txt with their dependencies.