### PR TITLE
Add mbedtls to dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ set(COMPONENT_ADD_INCLUDEDIRS "include")
 set(COMPONENT_PRIV_INCLUDEDIRS "lib/include")
 set(COMPONENT_SRCDIRS ". lib")
 
-set(COMPONENT_REQUIRES lwip nghttp)
+set(COMPONENT_REQUIRES lwip nghttp mbedtls)
 
 register_component()
 


### PR DESCRIPTION
Otherwise it fails to build not being able to find to find mbedtls includes.